### PR TITLE
added docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,32 +7,38 @@ we rebuild the server each time a new change is committed versus trying to upgra
 
 ## Setting up a Development Environment
 
-Please ensure docker is installed on your computer
+### Requirements
+| Package            | Version | Notes|
+|--------------------|---------|------|
+|[Git]               | Latest  | 
+|[Docker]            | 17.12.0+| Docker Download[(mac)](1)[(windows)](2)[(linux)](3) is highly recommended vs a package manager (homebrew, choco, apt, etc)
+|[Docker Compose]    | 3.7+    |
+|[Python]            | 3.4+    | Only required for running outside of docker
 
 ### Clone the repo
-```
+```bash
 git clone https://github.com/detroitblacktech/webportal -b staging
 cd webportal
-
 ```
 
-#### Using on Mac  
-```
-./deploy.sh Docker dev
-```
-
-#### Using on PC (haven't tested on PC - please fix)
-```
-docker build -t dsiprouter .
-docker rm -f dsiprouter-app
-docker run -p 80:80 -dit --restart always -v $PATH:/usr/src/dbt --name dsiprouter-app  dsiprouter
+### Running the Application (Docker)
+Given docker compose and docker, you can build and execute the app from command line. This should work
+across platforms (yay Docker!)
+```bash
+docker-compose up
 ```
 
-### Access the Website Local
+### Running the Application (Native)
+If you prefer to run the application without docker, make sure to have python requirements installed along with
+all dependencies of the application outlined in [build/requirements.txt](build/requirements.txt)
+```shell script
+pip install --no-cache-dir -r build/requirements.txt
+python app.py
+```
 
+### Access the Website Locally
 - Open a Web Browser
 - Enter http://localhost
-
 
 ### Making Changes
 
@@ -45,7 +51,6 @@ The application is built using the Python Flask Architecture.  Here are couple o
 - templates: all of the HTML that makes up the site is there.  The main layout is in a file called layout.html.  All new pages should inherit from that pages
 - app.py:  the main Python script that handles the routing of requests
 - terraform: contains the terraform scripts to provision to DigitalOcean, which is where our servers exists
-
 
 ### Commit Changes
 
@@ -68,3 +73,9 @@ To be clear, pull requests on the master branch will not be accepted.  We only a
 Join the Detroit Black Tech #website_dev_team
 
 Have Fun - This is a great way to learn and contribute to the group.
+[Git]: https://git-scm.com/downloads
+[Docker]: https://docs.docker.com/
+[Docker Compose]: https://docs.docker.com/compose/overview/
+[Python]: https://www.python.org/
+[1]: https://docs.docker.com/docker-for-mac/install/
+[2]: https://docs.docker.com/docker-for-windows/install/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.7'
+services:
+  dsiprouter-app:
+    build: .
+    restart: always
+    ports:
+      - "80:80"
+    volumes:
+      - "$PWD:/usr/src/dbt"
+    networks:
+      - dsiprouter-web
+      - default
+
+networks:
+  dsiprouter-web:

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -8,7 +8,7 @@
 	<head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<title>DBT: Detroit Black Tech 2019</title>
+	<title>DBT: Detroit Black Tech</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta name="description" content="Focused on building a community of Black individuals in the Detroit Tech Community that are highly valued" />
 	<meta name="keywords" content="detroit, black, developers, designers, project managers, devops" />

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -8,7 +8,7 @@
 	<head>
 	<meta charset="utf-8">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
-	<title>DBT: Detroit Black Tech</title>
+	<title>DBT: Detroit Black Tech 2019</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta name="description" content="Focused on building a community of Black individuals in the Detroit Tech Community that are highly valued" />
 	<meta name="keywords" content="detroit, black, developers, designers, project managers, devops" />

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -33,7 +33,7 @@ resource "digitalocean_droplet" "webserver" {
           "sudo add-apt-repository \"deb [arch=amd64] https://download.docker.com/linux/debian$(lsb_release -cs) stable\"",
           "sudo apt-get update",
           "sudo apt-get install docker-ce docker-ce-cli containerd.io",
-          "git clone ${var.repo}",
+          "git clone ${var.repo} -b ${var.branch}",
           "cd webportal",
           "./deploy.sh docker",
           "sleep 20"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,17 +4,17 @@ provider "digitalocean" {
 
 
 data "digitalocean_ssh_key" "ssh_key" {
-  name = "dopensource-training"
+  name = "dbt_dev"
 }
 
 
-resource "digitalocean_droplet" "kamailio-server" {
+resource "digitalocean_droplet" "webserver" {
         name = "${var.dropletname}-${count.index}"
         count = "${var.number_of_servers}"
         region = "nyc1"
         size="1gb"
         image="debian-9-x64"
-	      ssh_keys = [ "${data.digitalocean_ssh_key.ssh_key.fingerprint}" ]
+              ssh_keys = [ "${data.digitalocean_ssh_key.ssh_key.fingerprint}" ]
 
         connection {
         user = "root"
@@ -27,59 +27,26 @@ resource "digitalocean_droplet" "kamailio-server" {
           inline = [
           "export PATH=$PATH:/usr/bin",
           # install git repo and and server up the index page
-          "sudo hostnamectl set-hostname ${digitalocean_droplet.kamailio-server.name}.${var.domainname}",
-          "echo ${digitalocean_droplet.kamailio-server.ipv4_address}   ${digitalocean_droplet.kamailio-server.name}.${var.domainname} >> /etc/hosts",
-          "sudo mkdir -p ~/bits/kamailio",
-          "sudo apt-get update; sudo apt-get install -y git sngrep gcc g++ pkg-config libxml2-dev libssl-dev libcurl4-openssl-dev libpcre3-dev flex bison default-libmysqlclient-dev make autoconf mariadb-server",
-          "sleep 20",
-          "cd ~/bits",
-	  "git clone --depth 1 --no-single-branch https://github.com/kamailio/kamailio -b 5.3 kamailio",
-	  "cd ~/;git clone https://github.com/dOpensource/kamailio-admin-training",
-          "sleep 20",
-          "sed -i 's/\"set background=dark/set background=dark/' /etc/vim/vimrc"
-        ]
-
-      }
-}
-
-resource "digitalocean_droplet" "fusionpbx" {
-        name = "${var.fusionpbx-dropletname}${count.index}"
-        count = "${var.number_of_servers}"
-        region = "nyc1"
-        size="1gb"
-        image="debian-9-x64"
-	      ssh_keys = [ "${data.digitalocean_ssh_key.ssh_key.fingerprint}" ]
-
-        connection {
-        user = "root"
-        type = "ssh"
-        private_key = "${file(var.pvt_key)}"
-        timeout = "15m"
-        }
-
-        provisioner "remote-exec" {
-          inline = [
-          "export PATH=$PATH:/usr/bin",
-          # Setup VIM
-          "sed -i 's/\"set background=dark/set background=dark/' /etc/vim/vimrc",
-          # install FusionPBX
-          "wget -O - https://raw.githubusercontent.com/fusionpbx/fusionpbx-install.sh/master/debian/pre-install.sh | sh; cd /usr/src/fusionpbx-install.sh/debian && ./install.sh",
+          "sudo apt-get update",
+          "sudo apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common git",
+          "curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -",
+          "sudo add-apt-repository \"deb [arch=amd64] https://download.docker.com/linux/debian$(lsb_release -cs) stable\"",
+          "sudo apt-get update",
+          "sudo apt-get install docker-ce docker-ce-cli containerd.io",
+          "git clone ${var.repo}",
+          "cd webportal",
+          "./deploy.sh docker",
           "sleep 20"
         ]
+
       }
 }
+
 
 
 resource "digitalocean_record" "A-staging" {
-  domain = "dopensource.net"
+  domain = "detroitblacktech.org"
   type = "A"
-  name = "${digitalocean_droplet.kamailio-server.name}"
-  value = "${digitalocean_droplet.kamailio-server.ipv4_address}"
-}
-
-resource "digitalocean_record" "fusionpbx-A-record" {
-  domain = "dopensource.net"
-  type = "A"
-  name = "${digitalocean_droplet.fusionpbx.name}"
-  value = "${digitalocean_droplet.fusionpbx.ipv4_address}"
+  name = "staging"
+  value = "${digitalocean_droplet.webserver.ipv4_address}"
 }

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -1,7 +1,3 @@
-output "kamailio-server-ssh" {
-  value = "${digitalocean_droplet.kamailio-server.*.ipv4_address}"
-}
-
-output "fusionpbx-server-ssh" {
-  value = "${digitalocean_droplet.fusionpbx.*.ipv4_address}"
+output "ip" {
+  value = "${digitalocean_droplet.webserver.*.ipv4_address}"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,7 +3,7 @@ variable "do_token" {
 }
 
 variable "prefix" {
-
+	default=""
 }
 
 variable "pvt_key" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -23,5 +23,5 @@ variable "repo" {
 }
 
 variable "branch" {
-        default="dev"
+        default="staging"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,34 +1,27 @@
 variable "do_token" {
+
 }
 
 variable "prefix" {
-	default =""
+
 }
 
 variable "pvt_key" {
-  default = "~/.ssh/dopensource-training"
+  default = "~/.ssh/dbt_dev"
 }
 
 variable "dropletname" {
-  default = "kamailio-server"
-}
-
-variable "fusionpbx-dropletname" {
-  default = "fusionpbx"
+  default = "webserver"
 }
 
 variable "number_of_servers" {
   default = "1"
 }
 
-variable "domainname" {
-  default = "dopensource.net"
-}
-
 variable "repo" {
-	default="https://github.com/detroitblacktech/webportal.git"
+        default="https://github.com/detroitblacktech/webportal.git"
 }
 
 variable "branch" {
-	default="dev"
+        default="dev"
 }


### PR DESCRIPTION
docs: updated `README.md` for docker-compose instructions

build(docker-compose): added a `docker-compose.yml`

Added a `docker-compose.yml` to simplify running locally in docker.

Replicates the `README.md` directions of
`docker run -p 80:80 -dit --restart always -v $PATH:/usr/src/dbt --name dsiprouter-app  dsiprouter`

QA:
[-] checkout repository
[-] confirm that you have docker/docker-compose installed with
- docker version 18.06.0
- docker compose version 3.7
[-] execute `docker-compose up`, confirm there are no errors from the
logs
[-] confirm the site is available at http://localhost