### PR TITLE
added setuptools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM python:3.4
 WORKDIR /usr/src/dbt
-COPY build/requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
 EXPOSE 80
 COPY . .
+RUN pip install --no-cache-dir -r requirements.txt
 CMD [ "python", "./app.py" ]
 # Set proxy server, replace host:port with values for your servers
 ENV http_proxy host:port

--- a/modules/email.py
+++ b/modules/email.py
@@ -1,4 +1,5 @@
 import os, sys, settings
+#TODO: async conflicts with reserved word in python 3.7
 from util.decorator import async
 import smtplib
 from email import encoders

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
-build/requirements.txt
+--index-url https://pypi.python.org/simple/
+# The line below picks up dependencies described in setup.py install_requires
+-e .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+build/requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,50 @@
+"""Detroit Black Tech Web Portal
+See:
+https://packaging.python.org/en/latest/distributing.html
+https://github.com/pypa/sampleproject
+"""
+
+# Always prefer setuptools over distutils
+from setuptools import setup, find_packages
+# To use a consistent encoding
+from codecs import open
+from os import path
+
+here = path.abspath(path.dirname(__file__))
+
+# Get the long description from the README file
+with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
+
+setup(
+    name='dbt_webportal',  # Required
+    version='0.0.1',  # Required
+    maintainer='Detroit Black Tech',
+    maintainer_email='hello@detroitblacktech.com',
+    description='Detroit Black Technologists Web Presence',  # Required
+    long_description=long_description,  # Optional
+    url='https://github.com/detroitblacktech/webportal',  # Optional
+    classifiers=[  # Optional
+        'Development Status :: 2 - Pre-Alpha',
+        'Environment :: Web Environment',
+        'Framework :: Flask',
+        'Intended Audience :: End Users/Desktop',
+        'Programming Language :: Python :: 3.4', # TODO: we currently can't go past 3.6 because 3.7 conflicts with util/decorator.py#async
+    ],
+    keywords='detroit black tech',  # Optional
+    packages=find_packages(exclude=["tests/*"]),  # Required
+    install_requires=[
+        'flask-restplus',
+        'Flask-SQLAlchemy==2.1',
+        'sqlalchemy_utils',
+        'flask_cors',
+        'requests',
+        'jinja2',
+        'Flask-Script',
+        'mysqlclient',
+        'kafka-python'
+    ],  # Optional
+    extras_require={  # Optional
+        'test': ['black', 'pipenv', 'tox', 'tox-pipenv', 'coverage'],
+    }
+)


### PR DESCRIPTION
build(docker): changed Dockerfile to build from root requirements

This change moves the requirements build to use the requirements.txt
that uses setup.py (setuptools). This should bring the requirments a
developer might add to the repo closer to the deployment process
and reduce any impedance between how the app is deployed versus
how the app is developed.

Any decision to modify the `requirements.txt` in `build/` is left to
a different PR around the infrastructure / deployment process.

QA:
[-] execute a docker build, and confirm no errors
```
docker build -t dsiprouter .
```
[-] execute `deploy.sh docker dev` and confirm no errors
```
deploy.sh docker dev
```
[-] visit site at http://localhost
[-] find a song and serenade yourself on how cool coding is

feature(setuptools): new requirements.txt

Added a new requirements.txt that points to setup.py for app setup.
This requirements.txt will install the requirements based on the apps
defined dependencies.

QA:
[-] install through new requirements.txt at root of project
```
pip install --no-cache-dir -r requirements.txt
```
[-] run the application
```
python app.py
```
[-] were there no errors? Well aren't you a lucky tazmanian devil

build(setuptools): added a setup.py to the project

Added a `setup.py` for installation of the web portal through python
setuptools. This will prepare the app for build script.

Also created a symlink to the `build/requirements.txt` for now given
that we want to tell requirements.txt to use the setup.py for the app.

QA:
[-] install the app locally and confirm no errors
```
$python --version
Python 3.6.6
$ pip --version
pip 19.3.1 from /Users/me/.pyenv/versions/3.6.6/lib/python3.6/site-packages/pip (python 3.6)
$pip install -e .
```
[-] run the app
```
$ python app.py
 * Serving Flask app "app" (lazy loading)
 * Environment: production
   WARNING: This is a development server. Do not use it in a production deployment.
   Use a production WSGI server instead.
 * Debug mode: on
INFO:werkzeug: * Running on http://0.0.0.0:80/ (Press CTRL+C to quit)
INFO:werkzeug: * Restarting with stat
WARNING:werkzeug: * Debugger is active!
INFO:werkzeug: * Debugger PIN: 288-388-175
```
[-] comment on the nostalgia of the detroit black tech hero image